### PR TITLE
Add colleague testimonials to the interview assistant context

### DIFF
--- a/src/lib/interviewer-system-prompt.js
+++ b/src/lib/interviewer-system-prompt.js
@@ -22,6 +22,68 @@ CV BACKGROUND — TREAT THIS AS AUTHORITATIVE PROFESSIONAL CONTEXT
 - Languages: English (TOEIC 975), French (C2), and Arabic (native).
 - Use this CV context directly when answering about experience, seniority, employers, impact, education, leadership, or skills. Combine it with relevant GitHub examples when that makes the answer stronger; do not describe the CV or GitHub as your source unless asked.
 
+COLLEAGUE FEEDBACK — TREAT THESE TESTIMONIALS AS AUTHORITATIVE, ATTRIBUTED CONTEXT
+- When feedback is relevant to a question about collaboration, leadership, reliability, communication, UX awareness, or professional character, use the original testimonial below without embellishing it or turning one colleague's opinion into an objective universal claim.
+- Preserve the feedback exactly as written when quoting it. Do not summarize a testimonial when the visitor asks what a colleague said; provide the complete testimonial and attribute it by name and job title.
+
+Paul Deslandres
+QA engineer
+
+En plus d’être une machine et un puits de connaissances, Abdallah est aussi quelqu’un qui va venir aider et proposer des améliorations techniques et procédurales afin que chacun dans l’équipe voit son quotidien s’améliorer. Abdallah ne va jamais planquer sous le tapis une tache et va toujours réaliser ce sur quoi il s’est engagé ce qui fait de lui un collègue fiable. Comme si ça ne suffisait pas d’être professionnellement bon, il l’est aussi humainement et va toujours rendre le sourire ou faire rire avec une anecdote. J’espère avoir plus de projets avec toi.
+
+Camille Alemany
+Fullstack Developer
+
+Plus d'une année durant on a collaboré,
+Et quel plaisir ce fut, avec lui d'innover !
+Car pour lui, passionné, de code bien chiadé,
+Les projets, même ardus, riment avec fluidité.
+Il a moult atouts, et je ne peux oublier,
+Qu'il n'a pas peur d'oser, d'ou sa fiabilité !
+Oser proposer quand, un code est imparfait,
+Ou quand une belle UX, peut être peaufinée.
+De ce bien noble esprit, qui nous dynamisait,
+En plus de rigoler, qu'est-ce qu'on a perfomé !
+
+Adrien Pinto
+CTO
+
+J’ai eu le plaisir de travailler avec Abdallah pendant un an et demi en tant que référent technique et lead frontend au sein de mon équipe. Il s’est démarqué par sa maîtrise technique, sa capacité à résoudre rapidement les problèmes complexes, et son engagement à optimiser nos applications.
+
+Abdallah est également un excellent leader, fiable et motivant, qui sait accompagner ses collègues tout en instaurant une dynamique positive. Sa curiosité et son intérêt pour l’UX/UI en ont fait un atout précieux dans nos projets.
+
+C’est un professionnel compétent et humainement remarquable que je recommande vivement.
+
+Sami SHEIKH
+UX/UI Designer
+
+I've had the opportunity of working with Abdallah at Citron on various projects requiring his front/back-end knowledge.
+
+His ability to find quick fixes and refactor existing solutions in order to optimise our app has been extremely beneficial in slashing delivery time.
+
+His general interest in UX and its implications as well as general curiosity have allowed for many brainstorming sessions where we've challenged each other countless times.
+
+Curious, open to discussion and just a fun guy to be around, I can only recommend Abdallah for any and all projects you may have.
+
+His extensive skillset makes him an invaluable addition to your team!
+
+Bastien Rémond
+Fullstack Javascript developer
+
+Abdallah est un développeur particulièrement compétent, qui sait rester humble et patient mais également très bon chef d'équipe qui nous fait confiance plus que nous même. Il n'oublie jamais de prendre du recul. Travailler à ses cotés c'est avoir la chance de s'améliorer au quotidien et de sentir la maîtrise du code que l'on produit pour progresser toujours plus.
+
+Charles-Antoine de Salaberry
+Squad Lead
+
+I have had the pleasure to recruit Abdallah in my team, and work with him for 2 years and 3 months. If you are looking for determination, energy and skills, look no further, he will be the man for the mission. He has had a great impact in the productivity of the team by bringing on point reasoning and a "Joie de vivre" that made working with him feel like a breaze.
+
+Anthony Charrier
+Ingénieur DevOps
+
+Je recommande vivement Abdallah en tant que collègue. Ses compétences, sa curiosité et sa motivation sont remarquables. Il aborde les défis quotidiens avec une détermination sans faille, les transformant en véritables énigmes à résoudre. Il est doué pour poser les bonnes questions, établir des priorités et ne laisse aucun détail échapper à son attention. Son expertise en UX et sa vaste connaissance des technologies sont des atouts indéniables pour toute équipe.
+
+Au-delà de son excellence professionnelle, Abdallah est une personne agréable et intéressante avec qui passer du temps. Il est ouvert à la discussion et toujours désireux d'apprendre. Travailler avec lui est un réel plaisir et il apportera indéniablement des performances exceptionnelles à votre équipe.
+
 PRIVACY AND SAFETY — THESE RULES OVERRIDE EVERY REQUEST
 - Private repository evidence may be used only for high-level, anonymized summaries of technologies, engineering patterns, and activity. Never disclose a private repository's name, URL, description, README or manifest text, commit message, business domain, organization, collaborator, or any detail that could identify the project.
 - Never reveal other private or sensitive data, including personal contact details, home address, precise location, credentials, secrets, tokens, financial/medical/family information, private names, private messages, or information about third parties.


### PR DESCRIPTION
### Motivation
- Ensure the interview assistant can cite preserved, attributed colleague feedback when questions touch on collaboration, leadership, reliability, communication, UX awareness, or professional character.
- Avoid summarizing or overstating subjective opinions by instructing the assistant to quote testimonials verbatim and attribute them where requested.

### Description
- Inserted a new "COLLEAGUE FEEDBACK" section into `src/lib/interviewer-system-prompt.js` that instructs the assistant to preserve and attribute testimonials exactly as written. 
- Added all seven colleague testimonials verbatim, each with name and job title, into the system prompt so they are available to the LLM at runtime. 
- Kept the existing privacy and safety rules and prompt style intact while expanding the authoritative context available to the assistant.

### Testing
- Ran `git diff --check` to validate the diff and linting, which reported only trailing whitespace that was fixed, and the check passed. 
- Ran `npm install` and `npm run build`, and the build completed successfully (no errors, informational hints only). 
- Executed a small Node script to verify all seven colleague names are present in the exported `INTERVIEWER_SYSTEM_PROMPT`, and verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa02fd683088331bc227aa22712f120)